### PR TITLE
Rename "io" constants and stl subpackage to "ui"

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -64,9 +64,9 @@ public final class Constants {
   }
 
   /**
-   * Stores constants related to driver controls, SmartDashboard and other IO (Input/Output).
+   * Stores constants related to driver controls, SmartDashboard and other user interface elements.
    */
-  public static final class IOConstants {
+  public static final class UIConstants {
     public static final int DRIVER_JOYSTICK_INDEX = 0;
     public static final int OPERATOR_JOYSTICK_INDEX = 1;
 

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -9,13 +9,13 @@ import edu.wpi.first.wpilibj.smartdashboard.SendableChooser;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj2.command.Command;
 import frc.robot.Constants.DriveConstants.DriveMotorCANIDs;
-import frc.robot.Constants.IOConstants;
-import frc.robot.Constants.IOConstants.DriverAxes;
+import frc.robot.Constants.UIConstants;
+import frc.robot.Constants.UIConstants.DriverAxes;
 import frc.robot.commands.drive.StopDriveCommand;
 import frc.robot.commands.drive.TankDriveCommand;
 import frc.robot.subsystems.DriveBase;
+import lobstah.stl.ui.LobstahGamepad;
 import frc.robot.subsystems.AutonGenerator;
-import lobstah.stl.io.LobstahGamepad;
 
 /**
  * This class is where the bulk of the robot should be declared. Since Command-based is a "declarative" paradigm, very
@@ -31,8 +31,8 @@ public class RobotContainer {
 
   private final AutonGenerator autonGenerator = new AutonGenerator(driveBase);
 
-  private final LobstahGamepad driverJoystick = new LobstahGamepad(IOConstants.DRIVER_JOYSTICK_INDEX);
-  private final LobstahGamepad operatorJoystick = new LobstahGamepad(IOConstants.OPERATOR_JOYSTICK_INDEX);
+  private final LobstahGamepad driverJoystick = new LobstahGamepad(UIConstants.DRIVER_JOYSTICK_INDEX);
+  private final LobstahGamepad operatorJoystick = new LobstahGamepad(UIConstants.OPERATOR_JOYSTICK_INDEX);
 
   /**
    * The container for the robot. Contains subsystems, OI devices, and commands.
@@ -84,7 +84,7 @@ public class RobotContainer {
             driveBase,
             () -> -driverJoystick.getRawAxis(DriverAxes.LEFT),
             () -> -driverJoystick.getRawAxis(DriverAxes.RIGHT),
-            IOConstants.SQUARED_INPUTS));
+            UIConstants.SQUARED_INPUTS));
   }
 
   /**

--- a/src/main/java/lobstah/stl/ui/LobstahGamepad.java
+++ b/src/main/java/lobstah/stl/ui/LobstahGamepad.java
@@ -1,5 +1,5 @@
 
-package lobstah.stl.io;
+package lobstah.stl.ui;
 
 import edu.wpi.first.wpilibj.GenericHID;
 import edu.wpi.first.wpilibj2.command.button.JoystickButton;


### PR DESCRIPTION
The name "UI" better reflects the purpose of these items and avoids confusion with on-robot sensor/motor/etc. IO.